### PR TITLE
Basic infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.ghc.environment.*
+cabal.project.local
+
+/dist-*/
+/dist/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+PROJECT_NAME ?= fp-tic-tac-toe
+PROJECT_ROOT ?= $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+
+.PHONY: build
+build:
+	cabal v2-build
+
+.PHONY: run
+run:
+	cabal v2-run $(PROJECT_NAME)
+
+.PHONY: clean
+clean:
+	rm -rf $(PROJECT_ROOT)/dist
+	rm -rf $(PROJECT_ROOT)/dist-newstyle
+	rm -f  $(PROJECT_ROOT)/.ghc.environment.*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+## Setup
+
+To develop using [Nix](https://nixos.org/nix/), run `nix-shell`. This enters a shell where cabal and the appropriate version of GHC (specified in ./cabal.project) are provided.
+
+To develop without Nix, use [ghcup](https://gitlab.haskell.org/haskell/ghcup) to install the appropriate version of GHC (see ./cabal.project) and cabal. See ghcup's [usage examples](https://gitlab.haskell.org/haskell/ghcup#usage).
+
+## Build
+
+```sh
+make build
+```
+
+## Run
+
+```sh
+make run
+```

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/app/fp-tic-tac-toe.hs
+++ b/app/fp-tic-tac-toe.hs
@@ -1,0 +1,6 @@
+module Main (main) where
+
+import qualified FpTicTacToe.Main as M
+
+main :: IO ()
+main = M.main

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+packages: ./
+with-compiler: ghc-8.6.5

--- a/default.nix
+++ b/default.nix
@@ -8,6 +8,6 @@ in with pkgs;
 mkShell {
   buildInputs = [
     cabal-install
-    ghc
+    haskell.compiler.ghc865
   ];
 }

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,13 @@
+{ nixpkgs ? import <nixpkgs> }:
+
+let
+  pkgs = nixpkgs { };
+
+in with pkgs;
+
+mkShell {
+  buildInputs = [
+    cabal-install
+    ghc
+  ];
+}

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ nixpkgs ? import <nixpkgs> }:
+{ nixpkgs ? import nix/nixpkgs.nix }:
 
 let
   pkgs = nixpkgs { };

--- a/fp-tic-tac-toe.cabal
+++ b/fp-tic-tac-toe.cabal
@@ -1,0 +1,21 @@
+cabal-version:       >=1.10
+name:                fp-tic-tac-toe
+version:             0.1.0.0
+license:             BSD3
+author:              ivanbrennan
+maintainer:          ivan.brennan@gmail.com
+category:            Game
+build-type:          Simple
+
+library
+  exposed-modules:     FpTicTacToe.Main
+  build-depends:       base >=4.12 && <4.13
+  hs-source-dirs:      src
+  default-language:    Haskell2010
+
+executable fp-tic-tac-toe
+  main-is:             fp-tic-tac-toe.hs
+  build-depends:       base
+                     , fp-tic-tac-toe
+  hs-source-dirs:      app
+  default-language:    Haskell2010

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,4 @@
+let
+  pinned = builtins.fromJSON (builtins.readFile ./pinned.json);
+
+in import (builtins.fetchTarball pinned.nixpkgs)

--- a/nix/pinned.json
+++ b/nix/pinned.json
@@ -1,0 +1,6 @@
+{
+  "nixpkgs": {
+    "url": "https://github.com/NixOS/nixpkgs/archive/8746c77a383f5c76153c7a181f3616d273acfa2a.tar.gz",
+    "sha256": "1dvhx9hcij3j94yv102f7bhqy73k50sr3lazn28zzj8yg5lbahar"
+  }
+}

--- a/nix/update-nixpkgs.sh
+++ b/nix/update-nixpkgs.sh
@@ -1,0 +1,28 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i bash -p jq nix
+
+set -eu
+
+if (( $# != 1 ))
+then
+    echo "Usage: $0 <nixpkgs-revision>"
+    echo "e.g.   $0 8746c77a383f5c76153c7a181f3616d273acfa2a"
+    exit 1
+fi
+
+rev=$1
+url="https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz"
+
+pinned="$(dirname "$0")/pinned.json"
+tmpfile=$(mktemp pinned-XXXX)
+
+echo "Pre-fetching nixpkgs"
+sha256=$(
+    nix-prefetch-url "${url}" --unpack --type sha256 2>/dev/null
+)
+
+jq ".nixpkgs |= { url: \"${url}\", sha256: \"$sha256\" }" \
+  "${pinned}" > "$tmpfile"
+
+mv "$tmpfile" "${pinned}"
+echo "Updated ${pinned}"

--- a/src/FpTicTacToe/Main.hs
+++ b/src/FpTicTacToe/Main.hs
@@ -1,0 +1,6 @@
+module FpTicTacToe.Main
+  ( main
+  ) where
+
+main :: IO ()
+main = putStrLn "Hello, Haskell!"


### PR DESCRIPTION
Core dependencies: cabal and ghc. These can be provided by either [Nix](https://nixos.org/nix/) or [ghcup](https://gitlab.haskell.org/haskell/ghcup).

The project.cabal file specifies which version of GHC to use.

The Makefile contains common development commands, for convenience and documentation.

The default.nix file facilitates running a `nix-shell` development environment.