### PR TITLE
Fix README code-block styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,18 @@ To develop without Nix, use [ghcup](https://gitlab.haskell.org/haskell/ghcup) to
 
 ## Build
 
-```sh
+```
 make build
 ```
 
 ## Run
 
-```sh
+```
 make run
 ```
 
 ## Test
 
-```sh
+```
 make test
 ```


### PR DESCRIPTION
Prevent rendering from applying shell-script syntax highlighting to these code snippets. For example, since `test` is a shell builtin, the `make test` snippet was highlighting that word, despite the fact that we're not referring to the builtin here, but passing `test` as a command argument.